### PR TITLE
Add cross-platform transcript output pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,61 @@
 # whisper
-voice typing replica of Whisper flow
+
+Voice typing replica of Whisper flow with output automation utilities.
+
+## Output pipeline
+
+The `app.output` module delivers transcripts to the currently focused
+application through a combination of clipboard injection and simulated
+keystrokes. The workflow is designed to:
+
+- respect the user's focus by capturing and restoring the active window when
+  possible,
+- preserve Unicode content and UK spellings without auto-correcting dictated
+  text,
+- provide a quick-edit overlay before committing text, and
+- fall back gracefully by saving the transcript to disk and copying it to the
+  clipboard if automated delivery is unavailable.
+
+### Quick correction commands
+
+`OutputManager` exposes a handful of high-level helpers:
+
+- `send_transcript(text, quick_edit=False)` – normalises the text, optionally
+  opens the overlay editor for last-minute changes, and attempts to inject the
+  result.
+- `repeat_last_sentence()` – replays the most recent transcript using the same
+  injection strategies.
+- `open_overlay_editor(initial_text)` – open the overlay editor on demand
+  without immediately sending the text.
+
+### Optional dependencies
+
+The module uses optional OS-specific libraries when available:
+
+- `pywinauto` for Windows clipboard and key events,
+- `AppKit` (via `pyobjc`) for macOS clipboard access, and
+- `pyautogui` for cross-platform hotkeys and simulated typing.
+
+It falls back to Tkinter-based clipboard management and emits actionable
+warnings when none of the automation layers are available.
+
+### Manual end-to-end verification
+
+Manual scripts covering Windows, macOS, and Linux editors live in
+`scripts/manual`. Run the cross-platform helper:
+
+```bash
+python scripts/manual/run_output_manual.py [--quick-edit]
+```
+
+Detailed platform checklists are documented in
+[`scripts/manual/README.md`](scripts/manual/README.md).
+
+## Tests
+
+Automated unit tests validate text normalisation, fallback handling, history
+tracking, and overlay behaviour. Execute them with:
+
+```bash
+python -m pytest
+```

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""Application utilities for the Whisper-style voice typing workflow."""
+
+from .output import OutputManager, InjectionError, normalise_transcript
+
+__all__ = ["OutputManager", "InjectionError", "normalise_transcript"]

--- a/app/output.py
+++ b/app/output.py
@@ -1,0 +1,425 @@
+"""Utilities for delivering transcripts to the active application.
+
+This module coordinates clipboard injection, simulated keystrokes, and
+light-weight correction helpers so that speech-to-text transcripts can be
+committed to the currently focused application in a controlled way.  The
+implementation is intentionally defensive: it attempts platform-specific
+integration using optional dependencies and falls back to safe no-op behaviour
+when those dependencies are unavailable (for example inside headless test
+runs).
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+import logging
+import os
+import platform
+from pathlib import Path
+from typing import Callable, Deque, Optional, Sequence
+import unicodedata
+
+logger = logging.getLogger(__name__)
+
+
+class InjectionError(RuntimeError):
+    """Raised when text cannot be injected into the active application."""
+
+
+def normalise_transcript(text: str) -> str:
+    """Return a normalised representation of *text*.
+
+    The routine keeps the words as dictated (including UK spelling such as
+    "colour" or "organisation") while ensuring we have a consistent Unicode
+    normalisation form and that surrounding whitespace is tidy.  Leading and
+    trailing whitespace is trimmed, but internal line breaks are preserved.
+    """
+
+    if text is None:
+        raise TypeError("text cannot be None")
+
+    if not isinstance(text, str):
+        text = str(text)
+
+    normalised = unicodedata.normalize("NFC", text)
+    normalised = normalised.replace("\r\n", "\n").replace("\r", "\n")
+    normalised = "\n".join(line.rstrip() for line in normalised.split("\n"))
+    return normalised.strip()
+
+
+def _import_pyautogui():
+    try:
+        import pyautogui  # type: ignore
+
+        # Disable failsafe so we do not interrupt automation if the cursor hits
+        # the corner while typing; users can still enable it explicitly.
+        try:
+            pyautogui.FAILSAFE = False
+        except Exception:  # pragma: no cover - depends on pyautogui internals
+            pass
+        return pyautogui
+    except Exception as exc:  # pragma: no cover - executed only when missing
+        logger.debug("pyautogui unavailable: %s", exc)
+        return None
+
+
+def _import_pywinauto_clipboard():
+    try:
+        from pywinauto import clipboard  # type: ignore
+
+        return clipboard
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.debug("pywinauto clipboard unavailable: %s", exc)
+        return None
+
+
+def _import_pywinauto_sendkeys():
+    try:
+        from pywinauto.keyboard import SendKeys  # type: ignore
+
+        return SendKeys
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.debug("pywinauto SendKeys unavailable: %s", exc)
+        return None
+
+
+def _import_appkit_pasteboard():
+    try:
+        from AppKit import NSPasteboard, NSStringPboardType  # type: ignore
+
+        return NSPasteboard.generalPasteboard, NSStringPboardType
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.debug("AppKit pasteboard unavailable: %s", exc)
+        return None
+
+
+def _copy_to_clipboard(text: str) -> bool:
+    system = platform.system()
+    if system == "Windows":
+        clipboard = _import_pywinauto_clipboard()
+        if clipboard is not None:
+            try:
+                clipboard.copy(text)
+                return True
+            except Exception as exc:  # pragma: no cover - external dependency
+                logger.debug("pywinauto clipboard copy failed: %s", exc)
+
+    if system == "Darwin":
+        pasteboard_info = _import_appkit_pasteboard()
+        if pasteboard_info is not None:
+            general_pasteboard, string_type = pasteboard_info
+            try:  # pragma: no cover - requires macOS runtime
+                board = general_pasteboard()
+                board.clearContents()
+                board.setString_forType_(text, string_type)
+                return True
+            except Exception as exc:
+                logger.debug("AppKit pasteboard copy failed: %s", exc)
+
+    # Cross-platform tkinter clipboard fallback.
+    try:
+        import tkinter as tk  # type: ignore
+
+        root = tk.Tk()
+        root.withdraw()
+        root.clipboard_clear()
+        root.clipboard_append(text)
+        root.update()
+        root.destroy()
+        return True
+    except Exception as exc:  # pragma: no cover - depends on GUI availability
+        logger.debug("tkinter clipboard copy failed: %s", exc)
+
+    return False
+
+
+def _paste_from_clipboard(system: str) -> bool:
+    pyautogui = _import_pyautogui()
+
+    if system == "Windows":
+        sendkeys = _import_pywinauto_sendkeys()
+        if sendkeys is not None:
+            try:
+                sendkeys("^v")
+                return True
+            except Exception as exc:  # pragma: no cover - external dependency
+                logger.debug("pywinauto SendKeys failed: %s", exc)
+
+    if pyautogui is not None:
+        try:
+            if system == "Darwin":
+                pyautogui.hotkey("command", "v")
+            else:
+                pyautogui.hotkey("ctrl", "v")
+            return True
+        except Exception as exc:  # pragma: no cover - runtime specific
+            logger.debug("pyautogui hotkey failed: %s", exc)
+            if system not in {"Darwin"}:
+                try:
+                    pyautogui.hotkey("ctrl", "shift", "v")
+                    return True
+                except Exception as exc2:  # pragma: no cover
+                    logger.debug("pyautogui ctrl+shift+v failed: %s", exc2)
+
+    return False
+
+
+def _type_via_pyautogui(text: str, interval: float = 0.01) -> bool:
+    pyautogui = _import_pyautogui()
+    if pyautogui is None:
+        return False
+
+    try:
+        pyautogui.typewrite(text, interval=interval)
+        return True
+    except Exception as exc:  # pragma: no cover - runtime specific
+        logger.debug("pyautogui typewrite failed: %s", exc)
+        return False
+
+
+class ClipboardInjector:
+    """Inject text by copying to the clipboard then pasting it."""
+
+    def __call__(self, text: str) -> None:
+        prepared = normalise_transcript(text)
+        if not _copy_to_clipboard(prepared):
+            raise InjectionError("Unable to copy transcript to clipboard")
+
+        system = platform.system()
+        if not _paste_from_clipboard(system):
+            raise InjectionError("Unable to paste transcript via clipboard")
+
+
+class KeystrokeInjector:
+    """Inject text via simulated keystrokes."""
+
+    def __init__(self, interval: float = 0.01) -> None:
+        self.interval = interval
+
+    def __call__(self, text: str) -> None:
+        prepared = normalise_transcript(text)
+        if not _type_via_pyautogui(prepared, interval=self.interval):
+            raise InjectionError("Unable to type transcript via simulated keys")
+
+
+def default_injectors() -> Sequence[Callable[[str], None]]:
+    return (ClipboardInjector(), KeystrokeInjector())
+
+
+class FocusManager:
+    """Tracks and restores the application that was focused before output."""
+
+    def __init__(self, pyautogui_module=None) -> None:
+        self._pyautogui = pyautogui_module if pyautogui_module is not None else _import_pyautogui()
+        self._last_window = None
+
+    def capture(self) -> Optional[object]:
+        if self._pyautogui is None:
+            return None
+        get_window = getattr(self._pyautogui, "getActiveWindow", None)
+        if not callable(get_window):
+            return None
+        try:
+            self._last_window = get_window()
+        except Exception as exc:  # pragma: no cover - depends on runtime
+            logger.debug("Failed to capture active window: %s", exc)
+            self._last_window = None
+        return self._last_window
+
+    def restore(self) -> bool:
+        if self._last_window is None:
+            return False
+        activate = getattr(self._last_window, "activate", None)
+        if not callable(activate):
+            return False
+        try:
+            activate()
+            return True
+        except Exception as exc:  # pragma: no cover - depends on runtime
+            logger.debug("Failed to restore window focus: %s", exc)
+            return False
+
+
+def _fallback_path() -> Path:
+    env_path = os.getenv("WHISPER_OUTPUT_FALLBACK_PATH")
+    if env_path:
+        return Path(env_path).expanduser()
+
+    cache_home = Path(os.getenv("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache_home / "whisper" / "last_transcript.txt"
+
+
+def default_fallback_handler(text: str) -> Path:
+    """Persist the transcript so that the user can paste it manually later."""
+
+    fallback_file = _fallback_path()
+    fallback_file.parent.mkdir(parents=True, exist_ok=True)
+    fallback_file.write_text(text, encoding="utf-8")
+
+    if _copy_to_clipboard(text):
+        logger.warning(
+            "Automatic injection failed. The transcript was copied to the "
+            "clipboard and saved to %s.",
+            fallback_file,
+        )
+    else:
+        logger.warning(
+            "Automatic injection failed. The transcript is stored at %s.",
+            fallback_file,
+        )
+    return fallback_file
+
+
+def default_overlay_editor(initial_text: str, *, focus_manager: Optional[FocusManager] = None) -> str:
+    """Open a very small Tkinter overlay for last-minute corrections.
+
+    The editor is optional; if Tkinter is not available (for example in
+    headless CI) the function simply returns ``initial_text`` unchanged.  When
+    the editor is shown the previous application focus is restored afterwards.
+    """
+
+    try:
+        import tkinter as tk  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.debug("tkinter unavailable for overlay editor: %s", exc)
+        return initial_text
+
+    if focus_manager is not None:
+        focus_manager.capture()
+
+    result: dict[str, str] = {"text": initial_text}
+    finished = False
+
+    def on_confirm() -> None:
+        nonlocal finished
+        result["text"] = text_widget.get("1.0", "end-1c")
+        finished = True
+        root.destroy()
+
+    def on_cancel() -> None:
+        nonlocal finished
+        finished = True
+        root.destroy()
+
+    root = tk.Tk()
+    root.title("Quick transcript edit")
+    root.attributes("-topmost", True)
+    root.geometry("400x200")
+
+    text_widget = tk.Text(root, wrap="word")
+    text_widget.insert("1.0", initial_text)
+    text_widget.pack(expand=True, fill="both")
+
+    button_frame = tk.Frame(root)
+    button_frame.pack(fill="x", pady=4)
+    tk.Button(button_frame, text="Send", command=on_confirm).pack(side="left", expand=True)
+    tk.Button(button_frame, text="Cancel", command=on_cancel).pack(side="right", expand=True)
+
+    text_widget.focus_force()
+    root.mainloop()
+
+    if focus_manager is not None:
+        focus_manager.restore()
+
+    if not finished:
+        # The user closed the window via OS controls.
+        return initial_text
+
+    return normalise_transcript(result["text"])
+
+
+@dataclass
+class OutputManager:
+    """Manage transcript delivery and lightweight correction commands."""
+
+    injectors_factory: Optional[Callable[[], Sequence[Callable[[str], None]]]] = None
+    overlay_editor: Optional[Callable[[str], str]] = None
+    fallback_handler: Optional[Callable[[str], Path]] = None
+    focus_manager: FocusManager = field(default_factory=FocusManager)
+    history_limit: int = 50
+
+    def __post_init__(self) -> None:
+        if self.injectors_factory is None:
+            self._injectors = list(default_injectors())
+        else:
+            self._injectors = list(self.injectors_factory())
+
+        if self.overlay_editor is None:
+            self.overlay_editor = lambda text: default_overlay_editor(text, focus_manager=self.focus_manager)
+
+        if self.fallback_handler is None:
+            self.fallback_handler = default_fallback_handler
+
+        self._history: Deque[str] = deque(maxlen=self.history_limit)
+
+    @property
+    def history(self) -> Sequence[str]:
+        return tuple(self._history)
+
+    def send_transcript(self, text: str, *, quick_edit: bool = False) -> str:
+        """Deliver *text* to the active application.
+
+        When ``quick_edit`` is true the overlay editor is opened to allow the
+        user to polish the text before injection.  The method records the final
+        text in a bounded history so it can be repeated quickly.
+        """
+
+        prepared = normalise_transcript(text)
+
+        if quick_edit and self.overlay_editor is not None:
+            try:
+                prepared = self.overlay_editor(prepared)
+            except Exception as exc:
+                logger.warning("Overlay editor failed: %s", exc)
+
+        delivered = False
+        last_error: Optional[Exception] = None
+        for injector in self._injectors:
+            try:
+                injector(prepared)
+            except InjectionError as exc:
+                logger.debug("Injector %s failed: %s", injector, exc)
+                last_error = exc
+            except Exception as exc:  # pragma: no cover - defensive programming
+                logger.exception("Unexpected error from injector %s", injector)
+                last_error = exc
+            else:
+                delivered = True
+                break
+
+        self._history.append(prepared)
+
+        if not delivered:
+            try:
+                self.fallback_handler(prepared)
+            except Exception as exc:  # pragma: no cover - filesystem issues
+                logger.error("Fallback handler failed: %s", exc)
+                if last_error is not None:
+                    raise last_error
+                raise InjectionError("No injector succeeded and fallback failed") from exc
+        return prepared
+
+    def repeat_last_sentence(self) -> Optional[str]:
+        """Re-inject the most recent transcript."""
+
+        if not self._history:
+            return None
+
+        last_text = self._history[-1]
+        for injector in self._injectors:
+            try:
+                injector(last_text)
+                break
+            except InjectionError as exc:
+                logger.debug("Injector %s failed during repeat: %s", injector, exc)
+                continue
+        else:
+            self.fallback_handler(last_text)
+        self._history.append(last_text)
+        return last_text
+
+    def open_overlay_editor(self, initial_text: str) -> str:
+        if self.overlay_editor is None:
+            return normalise_transcript(initial_text)
+        return self.overlay_editor(normalise_transcript(initial_text))

--- a/scripts/manual/README.md
+++ b/scripts/manual/README.md
@@ -1,0 +1,63 @@
+# Manual output verification
+
+These guided scenarios exercise the `app.output` module against common editors on
+Windows, macOS, and Linux. Run them whenever you need to manually confirm end to
+end clipboard/typing integration on a workstation with GUI access.
+
+## Common preparation
+
+1. Install the optional dependencies for your platform (they are all optional
+   at runtime but make verification easier):
+
+   ```bash
+   pip install pyautogui
+   pip install pywinauto        # Windows only
+   pip install pyobjc-framework-AppKit  # macOS only
+   ```
+
+2. Ensure the voice-typing environment is in focus and that you can switch to
+   a text editor quickly. The scripts assume that the editor is already open and
+   ready to receive text.
+
+3. From the repository root run:
+
+   ```bash
+   python scripts/manual/run_output_manual.py
+   ```
+
+   The script waits a few seconds so you can focus the target editor before it
+   attempts clipboard or keystroke injection.
+
+## Windows (Notepad / WordPad)
+
+1. Open Notepad or WordPad and make sure the text caret is visible.
+2. Run the manual script as described above.
+3. When prompted, bring the editor to the foreground.
+4. Confirm that the sentence “Whisper output integration test.” appears. If it
+   does not, check that `pywinauto` and `pyautogui` are installed and that the
+   script has permission to control the keyboard.
+5. Trigger the quick edit scenario by running the script with `--quick-edit` and
+   validate that the Tkinter overlay appears and that the edited text is
+   committed to Notepad.
+
+## macOS (TextEdit)
+
+1. Launch TextEdit and open a plain-text document.
+2. Run the manual script and follow the on-screen countdown to switch focus to
+   TextEdit.
+3. Verify that the default sentence appears, keeping all accent marks intact.
+4. Run the script with `--quick-edit` to launch the overlay editor, adjust the
+   text, and ensure the updated copy is pasted into TextEdit.
+
+## Linux (Gedit / VS Code / LibreOffice Writer)
+
+1. Open one of the listed editors with a blank document.
+2. Execute the manual script. The script will attempt a clipboard paste and
+   fall back to simulated typing if the clipboard integration is unavailable.
+3. Confirm that the sentence is inserted; try again with `--quick-edit` to test
+   the overlay editor.
+4. If injection fails entirely, the script prints the path to a fallback file
+   that contains the transcript so you can copy it manually.
+
+Each scenario ends by repeating the last sentence using the quick correction
+command to verify that history tracking works as expected.

--- a/scripts/manual/run_output_manual.py
+++ b/scripts/manual/run_output_manual.py
@@ -1,0 +1,67 @@
+"""Manual verification helper for the output pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+from app.output import InjectionError, OutputManager
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--quick-edit",
+        action="store_true",
+        help="Open the overlay editor before sending text.",
+    )
+    parser.add_argument(
+        "--text",
+        default="Whisper output integration test.",
+        help="Transcript to deliver to the active window.",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=5.0,
+        help="Seconds to wait before sending text so you can focus the editor.",
+    )
+    parser.add_argument(
+        "--no-repeat",
+        action="store_true",
+        help="Skip repeating the last sentence after the initial delivery.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    manager = OutputManager()
+
+    logging.info("You have %.1f seconds to focus the target editor...", args.delay)
+    time.sleep(max(0.0, args.delay))
+
+    try:
+        delivered = manager.send_transcript(args.text, quick_edit=args.quick_edit)
+    except InjectionError as exc:
+        logging.error("Injection failed: %s", exc)
+        return 1
+
+    logging.info("Delivered transcript: %s", delivered)
+
+    if not args.no_repeat:
+        repeated = manager.repeat_last_sentence()
+        if repeated is None:
+            logging.warning("Repeat command could not run because history was empty.")
+        else:
+            logging.info("Repeated transcript: %s", repeated)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    raise SystemExit(main())

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,124 @@
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+from app.output import (
+    InjectionError,
+    OutputManager,
+    normalise_transcript,
+)
+
+
+class DummyInjector:
+    def __init__(self, succeed: bool = True) -> None:
+        self.succeed = succeed
+        self.calls = []
+
+    def __call__(self, text: str) -> None:
+        self.calls.append(text)
+        if not self.succeed:
+            raise InjectionError("simulated failure")
+
+
+class OutputManagerTests(unittest.TestCase):
+    def test_normalise_transcript_preserves_unicode_and_trims(self) -> None:
+        text = "  Héllo\r\ncolourful organisation  "
+        self.assertEqual(normalise_transcript(text), "Héllo\ncolourful organisation")
+
+    def test_send_transcript_uses_first_successful_injector(self) -> None:
+        injector = DummyInjector()
+        fallback_calls: list[str] = []
+
+        def fallback(text: str) -> Path:
+            fallback_calls.append(text)
+            path = Path(tempfile.gettempdir()) / "fallback.txt"
+            path.write_text(text, encoding="utf-8")
+            return path
+
+        manager = OutputManager(
+            injectors_factory=lambda: [injector],
+            overlay_editor=lambda text: text,
+            fallback_handler=fallback,
+        )
+
+        result = manager.send_transcript(" Hello world \n ")
+
+        self.assertEqual(result, "Hello world")
+        self.assertEqual(injector.calls, ["Hello world"])
+        self.assertEqual(fallback_calls, [])
+
+    def test_send_transcript_falls_back_when_all_injectors_fail(self) -> None:
+        failing = DummyInjector(succeed=False)
+        fallback_calls: list[str] = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            os.environ["WHISPER_OUTPUT_FALLBACK_PATH"] = str(Path(tmp) / "fallback.txt")
+
+            def fallback(text: str) -> Path:
+                fallback_calls.append(text)
+                path = Path(os.environ["WHISPER_OUTPUT_FALLBACK_PATH"])
+                path.write_text(text, encoding="utf-8")
+                return path
+
+            manager = OutputManager(
+                injectors_factory=lambda: [failing],
+                overlay_editor=lambda text: text,
+                fallback_handler=fallback,
+            )
+
+            result = manager.send_transcript("   test text   ")
+
+            self.assertEqual(result, "test text")
+            self.assertEqual(fallback_calls, ["test text"])
+
+            stored = Path(os.environ["WHISPER_OUTPUT_FALLBACK_PATH"])
+            self.assertTrue(stored.exists())
+            self.assertEqual(stored.read_text(encoding="utf-8"), "test text")
+
+        os.environ.pop("WHISPER_OUTPUT_FALLBACK_PATH", None)
+
+    def test_repeat_last_sentence_uses_history(self) -> None:
+        injector = DummyInjector()
+        manager = OutputManager(
+            injectors_factory=lambda: [injector],
+            overlay_editor=lambda text: text,
+            fallback_handler=lambda text: Path(tempfile.gettempdir()) / "fallback.txt",
+        )
+
+        manager.send_transcript("First line")
+        manager.send_transcript("Second line")
+
+        repeat = manager.repeat_last_sentence()
+
+        self.assertEqual(repeat, "Second line")
+        self.assertEqual(injector.calls[-2:], ["Second line", "Second line"])
+
+    def test_quick_edit_uses_overlay_callable(self) -> None:
+        injector = DummyInjector()
+
+        def overlay(text: str) -> str:
+            return text + " (edited)"
+
+        manager = OutputManager(
+            injectors_factory=lambda: [injector],
+            overlay_editor=overlay,
+            fallback_handler=lambda text: Path(tempfile.gettempdir()) / "fallback.txt",
+        )
+
+        manager.send_transcript("Original", quick_edit=True)
+
+        self.assertEqual(injector.calls, ["Original (edited)"])
+
+    def test_repeat_without_history_returns_none(self) -> None:
+        manager = OutputManager(
+            injectors_factory=lambda: [],
+            overlay_editor=lambda text: text,
+            fallback_handler=lambda text: Path(tempfile.gettempdir()) / "fallback.txt",
+        )
+
+        self.assertIsNone(manager.repeat_last_sentence())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an output manager that normalises transcripts and injects them via clipboard or simulated keystrokes with OS-specific fallbacks
- provide quick correction helpers including a Tkinter overlay editor and repeat-last-sentence command
- document manual end-to-end verification flows and add unit tests for history, fallback, and overlay behaviour

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68d286ab4850832f8f2b84cbee7a411e