### PR TITLE
Add resilient transcript fallback handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+pytest_cache/

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,9 @@
+"""Application package exposing transcript output helpers."""
+
+from .output import copy_to_clipboard, default_fallback_handler, send_transcript
+
+__all__ = [
+    "copy_to_clipboard",
+    "default_fallback_handler",
+    "send_transcript",
+]

--- a/app/output.py
+++ b/app/output.py
@@ -1,0 +1,158 @@
+"""Utilities for persisting generated transcripts to disk and the clipboard."""
+
+from __future__ import annotations
+
+import logging
+import tempfile
+from pathlib import Path
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+ClipboardCopier = Optional[Callable[[str], bool]]
+
+
+def copy_to_clipboard(text: str) -> bool:
+    """Attempt to copy *text* to the system clipboard.
+
+    The implementation relies on :mod:`pyperclip` when it is available.  The
+    function returns ``True`` when the copy succeeds and ``False`` otherwise.
+    Exceptions raised by the clipboard backend are caught and logged so the
+    caller can continue with secondary fallbacks.
+    """
+
+    try:
+        import pyperclip  # type: ignore
+    except ImportError:
+        logger.debug("pyperclip is not installed; clipboard copy skipped.")
+        return False
+
+    try:
+        pyperclip.copy(text)
+    except Exception as exc:  # pragma: no cover - backend specific exceptions
+        logger.warning("Failed to copy transcript to clipboard: %s", exc)
+        return False
+    return True
+
+
+def default_fallback_handler(
+    transcript: str,
+    fallback_path: Path,
+    *,
+    clipboard_copier: ClipboardCopier = copy_to_clipboard,
+    logger: Optional[logging.Logger] = None,
+) -> Optional[Path]:
+    """Persist *transcript* when the primary destination is unavailable.
+
+    The handler first tries to create the directory for ``fallback_path`` and
+    write the transcript there.  When those operations raise
+    :class:`OSError`/:class:`PermissionError` the handler falls back to a
+    guaranteed writable directory provided by :func:`tempfile.gettempdir`.
+
+    Regardless of where the transcript ultimately lands the handler still
+    attempts to copy it to the clipboard when a ``clipboard_copier`` is
+    supplied.  Any failure to both persist to disk *and* copy to the clipboard
+    is surfaced through a clear warning so that callers are aware of the data
+    loss.
+    """
+
+    active_logger = logger or logging.getLogger(__name__)
+
+    disk_success = False
+    clipboard_success = False
+    clipboard_exc: Optional[Exception] = None
+
+    final_path: Optional[Path] = fallback_path
+    alt_path = Path(tempfile.gettempdir()) / fallback_path.name
+
+    try:
+        fallback_path.parent.mkdir(parents=True, exist_ok=True)
+        fallback_path.write_text(transcript, encoding="utf-8")
+        disk_success = True
+    except (OSError, PermissionError) as exc:
+        try:
+            alt_path.parent.mkdir(parents=True, exist_ok=True)
+        except (OSError, PermissionError):
+            # The directory from ``gettempdir`` should already exist; if it
+            # does not we let the subsequent write raise and handle it below.
+            pass
+
+        try:
+            alt_path.write_text(transcript, encoding="utf-8")
+            final_path = alt_path
+            disk_success = True
+            active_logger.warning(
+                "Unable to write transcript to %s (%s). Wrote to fallback location %s.",
+                fallback_path,
+                exc,
+                alt_path,
+            )
+        except (OSError, PermissionError) as fallback_exc:
+            final_path = None
+            active_logger.warning(
+                "Unable to write transcript to %s (%s) or fallback location %s (%s).",
+                fallback_path,
+                exc,
+                alt_path,
+                fallback_exc,
+            )
+
+    if clipboard_copier is not None:
+        try:
+            clipboard_success = bool(clipboard_copier(transcript))
+        except Exception as exc:  # pragma: no cover - defensive logging
+            clipboard_exc = exc
+            clipboard_success = False
+
+    if disk_success:
+        if clipboard_copier is not None and not clipboard_success:
+            message = "Transcript stored at %s but failed to copy to clipboard"
+            if clipboard_exc is not None:
+                message += f" ({clipboard_exc})"
+            active_logger.warning(message + ".", final_path or fallback_path)
+    else:
+        if clipboard_success:
+            active_logger.warning(
+                "Transcript copied to clipboard because it could not be written to disk."
+            )
+        else:
+            message = "Failed to store transcript on disk and copy it to the clipboard"
+            if clipboard_exc is not None:
+                message += f" ({clipboard_exc})"
+            active_logger.warning(message + ".")
+
+    return final_path if disk_success else (final_path if clipboard_success else None)
+
+
+def send_transcript(
+    transcript: str,
+    output_path: Path | str,
+    *,
+    clipboard_copier: ClipboardCopier = copy_to_clipboard,
+    fallback_handler: Callable[..., Optional[Path]] = default_fallback_handler,
+    logger: Optional[logging.Logger] = None,
+) -> Optional[Path]:
+    """Write *transcript* to ``output_path``.
+
+    When writing the transcript fails due to permission issues the provided
+    ``fallback_handler`` is invoked so that the caller still receives a usable
+    location (or ``None`` when recovery is impossible).
+    """
+
+    active_logger = logger or logging.getLogger(__name__)
+    destination = Path(output_path)
+
+    try:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_text(transcript, encoding="utf-8")
+        return destination
+    except (OSError, PermissionError) as exc:
+        active_logger.warning("Failed to write transcript to %s: %s", destination, exc)
+        if fallback_handler is None:
+            raise
+        return fallback_handler(
+            transcript,
+            destination,
+            clipboard_copier=clipboard_copier,
+            logger=active_logger,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,110 @@
+import logging
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from app import output
+
+
+def test_send_transcript_success(tmp_path):
+    destination = tmp_path / "transcript.txt"
+    result = output.send_transcript("hello", destination)
+
+    assert result == destination
+    assert destination.exists()
+    assert destination.read_text(encoding="utf-8") == "hello"
+
+
+def test_send_transcript_unwritable_cache(monkeypatch, tmp_path, caplog):
+    destination = tmp_path / "cache" / "transcript.txt"
+
+    original_mkdir = Path.mkdir
+    original_write_text = Path.write_text
+
+    def failing_mkdir(self, *args, **kwargs):
+        if self == destination.parent:
+            raise PermissionError("cannot create directory")
+        return original_mkdir(self, *args, **kwargs)
+
+    def failing_write(self, *args, **kwargs):
+        if self == destination:
+            raise PermissionError("cannot write file")
+        return original_write_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", failing_mkdir)
+    monkeypatch.setattr(Path, "write_text", failing_write)
+
+    copied = []
+
+    def clipboard_success(text: str) -> bool:
+        copied.append(text)
+        return True
+
+    caplog.set_level(logging.WARNING)
+    result = output.send_transcript(
+        "fallback text", destination, clipboard_copier=clipboard_success
+    )
+
+    assert copied == ["fallback text"]
+    assert result is not None
+    assert result != destination
+    assert result.name == destination.name
+    assert result.parent == Path(tempfile.gettempdir())
+
+    messages = "\n".join(record.message for record in caplog.records)
+    assert "fallback location" in messages
+    assert str(result) in messages
+
+
+def test_fallback_logs_when_disk_and_clipboard_fail(monkeypatch, tmp_path, caplog):
+    destination = tmp_path / "transcript.txt"
+
+    def always_fail_write(self, *args, **kwargs):
+        raise PermissionError("no disk access")
+
+    def noop_mkdir(self, *args, **kwargs):
+        return None
+
+    monkeypatch.setattr(Path, "write_text", always_fail_write)
+    monkeypatch.setattr(Path, "mkdir", noop_mkdir)
+
+    def clipboard_failure(_: str) -> bool:
+        raise RuntimeError("clipboard offline")
+
+    caplog.set_level(logging.WARNING)
+    result = output.send_transcript(
+        "content", destination, clipboard_copier=clipboard_failure
+    )
+
+    assert result is None
+    messages = "\n".join(record.message for record in caplog.records)
+    assert "Failed to store transcript on disk and copy it to the clipboard" in messages
+    assert "fallback location" in messages
+
+
+@pytest.mark.parametrize("clipboard_returns", [True, False])
+def test_default_fallback_handler_attempts_clipboard(monkeypatch, clipboard_returns):
+    destination = Path("/unwritable/transcript.txt")
+
+    def always_fail_write(self, *args, **kwargs):
+        raise PermissionError("no disk access")
+
+    def noop_mkdir(self, *args, **kwargs):
+        return None
+
+    monkeypatch.setattr(Path, "write_text", always_fail_write)
+    monkeypatch.setattr(Path, "mkdir", noop_mkdir)
+
+    called = {}
+
+    def clipboard_mock(text: str) -> bool:
+        called.setdefault("count", 0)
+        called["count"] += 1
+        return clipboard_returns
+
+    output.default_fallback_handler(
+        "transcript", destination, clipboard_copier=clipboard_mock
+    )
+
+    assert called["count"] == 1


### PR DESCRIPTION
## Summary
- add transcript output helpers with clipboard-aware fallback handling
- fallback to a writable temp directory when the main cache path cannot be written
- extend the test suite to cover unwritable cache scenarios and clipboard fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d395de0394832fb088109da275fd66