### PR TITLE
Add tray UI with hotkeys and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,90 @@
-# whisper
-voice typing replica of Whisper flow
+# whisper desktop controller
+
+A lightweight desktop companion for Whisper-style voice typing. The tray icon
+lets you toggle the transcriber service, view status, and quit the app without
+opening a terminal. Hotkeys, including auxiliary mouse buttons, can be
+customised to match your workflow.
+
+## Features
+
+- Cross-platform tray icon with start/stop/status menu items powered by
+  [`pystray`](https://github.com/moses-palmer/pystray).
+- Keyboard and mouse hotkey support using the [`keyboard`](https://github.com/boppreh/keyboard)
+  and [`mouse`](https://github.com/boppreh/mouse) libraries.
+- Visual state feedback via icon colour and tooltip text for stopped, listening,
+  transcribing, and error states.
+- Audible feedback cues for key lifecycle events.
+- Structured logging with timestamps for troubleshooting.
+
+## Requirements
+
+- Python 3.9+
+- Desktop environment that supports system tray icons (Windows, macOS, or most
+  Linux distributions running a modern DE).
+- The `keyboard` library may require administrator/root privileges on Linux and
+  macOS. Consult the library documentation if hotkeys do not trigger.
+
+Install Python dependencies with:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Hotkeys and runtime behaviour live in `config.json`. Copy the example file and
+adjust values to suit your setup:
+
+```bash
+cp config.example.json config.json
+```
+
+Available fields:
+
+| Field | Description | Default |
+| --- | --- | --- |
+| `hotkey` | Keyboard hotkey string recognised by the `keyboard` library (e.g. `ctrl+shift+space`). | `ctrl+shift+space` |
+| `mouse_button` | Optional mouse button trigger. Use `x1` or `x2` for side buttons, or `left`/`right`/`middle`. Set to `null` to disable. | `null` |
+| `start_on_launch` | If `true`, the transcriber begins listening as soon as the tray icon loads. | `false` |
+| `log_file` | Location for the application log file. Parent directories are created automatically. | `logs/whisper-ui.log` |
+
+The example `config.example.json` enables the first side mouse button (`x1`) and can
+be edited to suit your gear. Changes take effect the next time you launch the tray
+application. If no `config.json` is found the defaults above are used automatically.
+
+## Usage
+
+1. Activate your virtual environment if not already active.
+2. Start the tray controller:
+
+   ```bash
+   python main.py
+   ```
+
+3. A tray icon appears:
+   - Grey – stopped
+   - Blue – listening for audio
+   - Green – actively transcribing
+   - Red – error state
+
+4. Use the configured hotkey or the tray menu to start/stop the transcriber.
+   State changes emit short beeps; errors use a lower tone to stand out.
+5. View `logs/whisper-ui.log` for diagnostic information such as hotkey
+   registration and state transitions.
+
+Quit the application from the tray menu or by closing the terminal window used
+to launch it.
+
+## Extending the transcriber
+
+The included `TranscriberService` is a lightweight state machine. Integrate
+your audio capture and Whisper pipeline by calling:
+
+- `begin_transcription()` before audio is sent to Whisper.
+- `complete_transcription()` when Whisper returns text.
+- `set_error("message")` to surface failures in the tray UI and logs.
+
+These callbacks keep the UI responsive while your own transcription logic runs
+in the background.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,12 @@
+"""Application package for the Whisper desktop controller."""
+
+from .config import Settings  # noqa: F401
+from .transcriber import TranscriberService, TranscriberState  # noqa: F401
+from .ui import TrayApplication  # noqa: F401
+
+__all__ = [
+    "Settings",
+    "TranscriberService",
+    "TranscriberState",
+    "TrayApplication",
+]

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,61 @@
+"""Configuration helpers for the Whisper desktop controller."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, fields
+from pathlib import Path
+from typing import Any, Dict
+
+LOGGER = logging.getLogger(__name__)
+
+CONFIG_FILE_NAME = "config.json"
+
+
+@dataclass
+class Settings:
+    """Strongly typed user configuration for the desktop controller."""
+
+    hotkey: str = "ctrl+shift+space"
+    mouse_button: str | None = None
+    start_on_launch: bool = False
+    log_file: str = "logs/whisper-ui.log"
+
+    @classmethod
+    def load(cls, path: str | Path | None = None) -> "Settings":
+        """Load configuration from ``path`` or the default ``config.json``.
+
+        Missing files fall back to the class defaults.
+        """
+
+        config_path = Path(path) if path else Path(CONFIG_FILE_NAME)
+        values: Dict[str, Any] = {}
+        if config_path.exists():
+            try:
+                with config_path.open("r", encoding="utf-8") as handle:
+                    raw = json.load(handle)
+            except json.JSONDecodeError as exc:  # pragma: no cover - defensive path
+                LOGGER.error("Invalid JSON in %%s: %%s", config_path, exc)
+                raw = {}
+        else:
+            LOGGER.info(
+                "Configuration file %%s not found – falling back to defaults.",
+                config_path,
+            )
+            raw = {}
+
+        for field in fields(cls):
+            if field.name in raw:
+                values[field.name] = raw[field.name]
+
+        settings = cls(**values)
+        LOGGER.debug("Loaded settings: %%s", settings)
+        return settings
+
+    def ensure_log_directory(self) -> Path:
+        """Create the directory that will contain the log file if needed."""
+
+        log_path = Path(self.log_file)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        return log_path

--- a/app/feedback.py
+++ b/app/feedback.py
@@ -1,0 +1,100 @@
+"""Utilities for producing audible feedback for the tray UI."""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import threading
+from dataclasses import dataclass
+
+from .transcriber import TranscriberState
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class FeedbackTone:
+    frequency: int
+    duration_ms: int
+    repeat: int = 1
+
+
+DEFAULT_TONES = {
+    TranscriberState.LISTENING: FeedbackTone(880, 120),
+    TranscriberState.TRANSCRIBING: FeedbackTone(660, 120, repeat=2),
+    TranscriberState.ERROR: FeedbackTone(220, 300, repeat=2),
+}
+
+
+class FeedbackPlayer:
+    """Plays simple beeps using platform-specific mechanisms."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def play(self, state: TranscriberState) -> None:
+        tone = DEFAULT_TONES.get(state)
+        if not tone:
+            return
+        threading.Thread(target=self._play_tone, args=(tone,), daemon=True).start()
+
+    def _play_tone(self, tone: FeedbackTone) -> None:
+        with self._lock:
+            for _ in range(tone.repeat):
+                try:
+                    self._beep(tone.frequency, tone.duration_ms)
+                except Exception:  # pragma: no cover - platform specific fallback
+                    LOGGER.exception("Failed to play feedback tone")
+                    break
+
+    @staticmethod
+    def _beep(frequency: int, duration_ms: int) -> None:
+        system = platform.system().lower()
+        if system == "windows":
+            import winsound
+
+            winsound.Beep(frequency, duration_ms)
+            return
+
+        if system == "darwin":
+            subprocess.run(["osascript", "-e", "beep"], check=False)
+            return
+
+        if shutil.which("play"):
+            subprocess.run(
+                [
+                    "play",
+                    "-nq",
+                    "-t",
+                    "alsa",
+                    "synth",
+                    str(duration_ms / 1000.0),
+                    "sin",
+                    str(frequency),
+                ],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return
+
+        if shutil.which("beep"):
+            subprocess.run(
+                ["beep", "-f", str(frequency), "-l", str(duration_ms)],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return
+
+        sys.stdout.write("\a")
+        sys.stdout.flush()
+        try:
+            fd = sys.stdout.fileno()
+            os.fsync(fd)
+        except (AttributeError, OSError):
+            pass

--- a/app/transcriber.py
+++ b/app/transcriber.py
@@ -1,0 +1,113 @@
+"""Simple transcriber service state machine used by the desktop UI."""
+
+from __future__ import annotations
+
+import enum
+import logging
+from threading import RLock
+from typing import Callable, List
+
+LOGGER = logging.getLogger(__name__)
+
+
+class TranscriberState(enum.Enum):
+    """Lifecycle state of the transcription engine."""
+
+    STOPPED = "stopped"
+    LISTENING = "listening"
+    TRANSCRIBING = "transcribing"
+    ERROR = "error"
+
+
+StateCallback = Callable[["TranscriberState"], None]
+
+
+class TranscriberService:
+    """State container that mirrors a transcription engine.
+
+    The implementation here focuses on state tracking.  Projects can plug in
+    their own audio capture and Whisper integration and call ``begin_transcription``
+    and ``complete_transcription`` to update the tray UI.
+    """
+
+    def __init__(self) -> None:
+        self._state = TranscriberState.STOPPED
+        self._callbacks: List[StateCallback] = []
+        self._lock = RLock()
+
+    @property
+    def state(self) -> TranscriberState:
+        with self._lock:
+            return self._state
+
+    def register_state_callback(self, callback: StateCallback) -> None:
+        """Register a callback invoked whenever the state changes."""
+
+        self._callbacks.append(callback)
+
+    def _notify(self) -> None:
+        for callback in list(self._callbacks):
+            try:
+                callback(self._state)
+            except Exception:  # pragma: no cover - defensive logging
+                LOGGER.exception("State callback failed")
+
+    def start(self) -> None:
+        """Set the service state to :class:`TranscriberState.LISTENING`."""
+
+        with self._lock:
+            if self._state == TranscriberState.LISTENING:
+                LOGGER.debug("Transcriber already in listening state")
+                return
+            LOGGER.info("Transcriber listening started")
+            self._state = TranscriberState.LISTENING
+        self._notify()
+
+    def stop(self) -> None:
+        """Return the service to the :class:`TranscriberState.STOPPED` state."""
+
+        with self._lock:
+            if self._state == TranscriberState.STOPPED:
+                LOGGER.debug("Transcriber already stopped")
+                return
+            LOGGER.info("Transcriber stopped")
+            self._state = TranscriberState.STOPPED
+        self._notify()
+
+    def toggle(self) -> TranscriberState:
+        """Toggle between running and stopped states."""
+
+        with self._lock:
+            if self._state in (TranscriberState.STOPPED, TranscriberState.ERROR):
+                self._state = TranscriberState.LISTENING
+                LOGGER.info("Transcriber listening started via toggle")
+            else:
+                self._state = TranscriberState.STOPPED
+                LOGGER.info("Transcriber stopped via toggle")
+            new_state = self._state
+        self._notify()
+        return new_state
+
+    def begin_transcription(self) -> None:
+        """Mark that audio is actively being transcribed."""
+
+        with self._lock:
+            LOGGER.info("Transcription started")
+            self._state = TranscriberState.TRANSCRIBING
+        self._notify()
+
+    def complete_transcription(self) -> None:
+        """Return to the listening state once transcription finished."""
+
+        with self._lock:
+            LOGGER.info("Transcription finished")
+            self._state = TranscriberState.LISTENING
+        self._notify()
+
+    def set_error(self, message: str) -> None:
+        """Set the state to :class:`TranscriberState.ERROR` with log context."""
+
+        with self._lock:
+            LOGGER.error("Transcriber error: %s", message)
+            self._state = TranscriberState.ERROR
+        self._notify()

--- a/app/ui.py
+++ b/app/ui.py
@@ -1,0 +1,186 @@
+"""Desktop tray user interface for controlling the transcriber service."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections.abc import Callable
+from typing import Dict, Optional
+
+import keyboard
+import mouse
+import pystray
+from PIL import Image, ImageDraw
+
+from .config import Settings
+from .feedback import FeedbackPlayer
+from .transcriber import TranscriberService, TranscriberState
+
+LOGGER = logging.getLogger(__name__)
+
+ICON_SIZE = (64, 64)
+ICON_COLORS = {
+    TranscriberState.STOPPED: "#4b5563",  # slate grey
+    TranscriberState.LISTENING: "#2563eb",  # blue
+    TranscriberState.TRANSCRIBING: "#16a34a",  # green
+    TranscriberState.ERROR: "#dc2626",  # red
+}
+
+
+class TrayApplication:
+    """System tray application binding hotkeys to the transcriber service."""
+
+    def __init__(self, service: TranscriberService, settings: Settings) -> None:
+        self.service = service
+        self.settings = settings
+        self.feedback = FeedbackPlayer()
+        self._keyboard_handle: Optional[int] = None
+        self._mouse_handler: Optional[Callable[[object], None]] = None
+        self._icons: Dict[TranscriberState, Image.Image] = self._generate_icons()
+        self._status_text = self._format_status(TranscriberState.STOPPED)
+        self._menu_lock = threading.Lock()
+
+        self.icon = pystray.Icon(
+            name="Whisper",
+            icon=self._icons[TranscriberState.STOPPED],
+            title=self._tooltip_for_state(TranscriberState.STOPPED),
+            menu=self._build_menu(),
+        )
+        self.service.register_state_callback(self._on_state_change)
+
+    def run(self) -> None:
+        """Start the tray application."""
+
+        LOGGER.info("Launching tray icon")
+        self.icon.run(setup=self._setup)
+
+    def stop(self) -> None:
+        """Stop the tray application and unregister hotkeys."""
+
+        LOGGER.info("Stopping tray icon")
+        self._unregister_hotkeys()
+        try:
+            self.service.stop()
+        finally:
+            self.icon.visible = False
+            self.icon.stop()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _setup(self, _icon: pystray.Icon) -> None:
+        self._register_hotkeys()
+        if self.settings.start_on_launch:
+            LOGGER.info("Start on launch enabled")
+            self.service.start()
+
+    def _build_menu(self) -> pystray.Menu:
+        return pystray.Menu(
+            pystray.MenuItem(self._status_text, None, enabled=False),
+            pystray.MenuItem("Start listening", self._menu_start),
+            pystray.MenuItem("Stop listening", self._menu_stop),
+            pystray.MenuItem("Quit", self._menu_quit),
+        )
+
+    def _generate_icons(self) -> Dict[TranscriberState, Image.Image]:
+        icons: Dict[TranscriberState, Image.Image] = {}
+        for state, color in ICON_COLORS.items():
+            image = Image.new("RGBA", ICON_SIZE, (0, 0, 0, 0))
+            draw = ImageDraw.Draw(image)
+            draw.ellipse((8, 8, ICON_SIZE[0] - 8, ICON_SIZE[1] - 8), fill=color)
+            icons[state] = image
+        return icons
+
+    def _tooltip_for_state(self, state: TranscriberState) -> str:
+        return f"Whisper – {state.value.title()}"
+
+    def _format_status(self, state: TranscriberState) -> str:
+        return f"Status: {state.value.title()}"
+
+    def _on_state_change(self, state: TranscriberState) -> None:
+        LOGGER.info("State changed to %s", state.value)
+        self.feedback.play(state)
+        with self._menu_lock:
+            self._status_text = self._format_status(state)
+            self.icon.icon = self._icons[state]
+            self.icon.title = self._tooltip_for_state(state)
+            self.icon.menu = self._build_menu()
+            self.icon.update_menu()
+
+    def _register_hotkeys(self) -> None:
+        try:
+            self._keyboard_handle = keyboard.add_hotkey(
+                self.settings.hotkey, self._handle_toggle, suppress=False
+            )
+            LOGGER.info("Registered hotkey: %s", self.settings.hotkey)
+        except Exception:
+            LOGGER.exception("Failed to register keyboard hotkey '%s'", self.settings.hotkey)
+
+        if self.settings.mouse_button:
+            button = self._normalise_mouse_button(self.settings.mouse_button)
+            if button:
+                try:
+                    self._mouse_handler = mouse.on_button(
+                        self._handle_mouse_toggle, buttons=(button,), types=("down",)
+                    )
+                    LOGGER.info("Registered mouse button hotkey: %s", button)
+                except Exception:
+                    LOGGER.exception("Failed to register mouse hotkey '%s'", button)
+            else:
+                LOGGER.warning("Unsupported mouse button configured: %s", self.settings.mouse_button)
+
+    def _unregister_hotkeys(self) -> None:
+        if self._keyboard_handle is not None:
+            try:
+                keyboard.remove_hotkey(self._keyboard_handle)
+                LOGGER.info("Keyboard hotkey removed")
+            except Exception:
+                LOGGER.exception("Failed to remove keyboard hotkey")
+            self._keyboard_handle = None
+
+        if self._mouse_handler is not None:
+            try:
+                mouse.unhook(self._mouse_handler)
+                LOGGER.info("Mouse hotkey removed")
+            except Exception:
+                LOGGER.exception("Failed to remove mouse hotkey")
+            self._mouse_handler = None
+
+    def _handle_toggle(self) -> None:
+        LOGGER.info("Hotkey pressed – toggling service")
+        state = self.service.toggle()
+        if state == TranscriberState.ERROR:
+            LOGGER.error("Service entered error state after toggle")
+
+    def _handle_mouse_toggle(self, event: object) -> None:
+        if getattr(event, 'event_type', None) != 'down':
+            return
+        LOGGER.info("Mouse button hotkey pressed – toggling service")
+        self._handle_toggle()
+
+    @staticmethod
+    def _normalise_mouse_button(button: str) -> Optional[str]:
+        mapping = {
+            "x1": "x",  # mouse library uses "x" for the first side button
+            "x2": "x2",
+            "left": "left",
+            "right": "right",
+            "middle": "middle",
+        }
+        return mapping.get(button.lower())
+
+    # ------------------------------------------------------------------
+    # Menu callbacks
+    # ------------------------------------------------------------------
+    def _menu_start(self, _: pystray.Icon, __: pystray.MenuItem) -> None:
+        LOGGER.info("Start selected from tray menu")
+        self.service.start()
+
+    def _menu_stop(self, _: pystray.Icon, __: pystray.MenuItem) -> None:
+        LOGGER.info("Stop selected from tray menu")
+        self.service.stop()
+
+    def _menu_quit(self, icon: pystray.Icon, _: pystray.MenuItem) -> None:
+        LOGGER.info("Quit selected from tray menu")
+        self.stop()
+

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,6 @@
+{
+  "hotkey": "ctrl+shift+space",
+  "mouse_button": "x1",
+  "start_on_launch": false,
+  "log_file": "logs/whisper-ui.log"
+}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,33 @@
+"""Entry point for the Whisper desktop tray controller."""
+
+from __future__ import annotations
+
+import logging
+
+from app import Settings, TrayApplication, TranscriberService
+
+
+def configure_logging(settings: Settings) -> None:
+    log_path = settings.ensure_log_directory()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=[
+            logging.FileHandler(log_path, encoding="utf-8"),
+            logging.StreamHandler(),
+        ],
+    )
+
+
+def main() -> None:
+    settings = Settings.load()
+    configure_logging(settings)
+
+    service = TranscriberService()
+    tray = TrayApplication(service, settings)
+
+    tray.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+keyboard>=0.13
+mouse>=0.7
+pystray>=0.19
+Pillow>=10.0


### PR DESCRIPTION
## Summary
- add a tray-based UI with visual state indicators, menu actions, and keyboard/mouse hotkeys
- add a lightweight transcriber state service with audible feedback hooks and configuration loader
- document setup, hotkey customisation, and logging in the README with a sample config file

## Testing
- python -m compileall app main.py

------
https://chatgpt.com/codex/tasks/task_e_68d286a8b504832fbf6bc520a6cb0889